### PR TITLE
Fix ALOnboardingRole lambda role s3 perm

### DIFF
--- a/template/ct-al-master-onboarding.yaml
+++ b/template/ct-al-master-onboarding.yaml
@@ -70,7 +70,7 @@ Parameters:
     Description: Target regions for AlertLogic deployment
     Default: us-east-1
   FullRegionCoverage:
-    Type: String 
+    Type: String
     Description: AlertLogic full region deployment scope (yes / no)
     Default: true
     AllowedValues:
@@ -90,7 +90,7 @@ Parameters:
     NoEcho: True
     Description: AlertLogic API Secret Key / Password
   AlertLogicDeploymentMode:
-    Type: String 
+    Type: String
     Description: >-
         Set to 'Automatic' if you want Alert Logic to create subnets for ids and scanning appliances.
         If you want to deploy Alert Logic appliances yourself, set this option to 'Manual'
@@ -121,8 +121,8 @@ Parameters:
       - Production
       - Integration
 
-Metadata: 
-  AWS::CloudFormation::Interface: 
+Metadata:
+  AWS::CloudFormation::Interface:
     ParameterGroups:
       -
         Label:
@@ -139,7 +139,7 @@ Metadata:
           - FullRegionCoverage
           - CoverageTags
           - EnableGuardDutyIntegration
-      - 
+      -
         Label:
           default: "AWS Control Tower Information"
         Parameters:
@@ -158,7 +158,7 @@ Metadata:
           - AlertLogicGuardDutyCollectorStackSetName
           - AlertLogicGuardDutyCollectorTemplateUrl
           - SourceBucket
-    ParameterLabels: 
+    ParameterLabels:
       AlertLogicCustomerId:
         default: "Alert Logic Customer ID"
       AlertLogicAPIAccessKey:
@@ -188,7 +188,7 @@ Metadata:
       AuditAccount:
         default: "Audit Account ID"
 
-Mappings: 
+Mappings:
   SourceCode:
     Key:
       LifeCycle: "lambda_packages/lifecycle_1.0.1.zip"
@@ -210,7 +210,7 @@ Resources:
           - '","ALCID": "'
           - Ref: AlertLogicCustomerId
           - '"}'
-  
+
   ALOnboarding:
     Type: "AWS::Lambda::Function"
     Properties:
@@ -291,7 +291,7 @@ Resources:
               - !Sub 'arn:aws:s3:::alertlogic-cloud-formation-templates-733251395267/*'
               - !Sub 'arn:aws:s3:::alertlogic-cloud-formation-templates-948063967832/*'
               - !Sub 'arn:aws:s3:::alertlogic-cloud-formation-templates-857795874556/*'
-              - !Sub 'arn:aws:s3:::alertlogic-collectors-us-east-1/cfn/*'
+              - !Sub 'arn:aws:s3:::alertlogic-collectors-*/cfn/*'
           - Effect: Allow
             Action:
               - organizations:ListAccounts
@@ -396,7 +396,7 @@ Resources:
     Type: "AWS::CloudFormation::CustomResource"
     Properties:
       ServiceToken: !GetAtt ALOnboarding.Arn
-      OrgId: !Ref OrgId  
+      OrgId: !Ref OrgId
       Secret: !Ref ALCredentials
       SecurityAccount: !Ref SecurityAccount
       LogArchiveAccount: !Ref LogArchiveAccount


### PR DESCRIPTION
Related to VTT#[2786](https://alertlogic.atlassian.net/browse/VTT-2786)

ALOnboardingRole requires access to the GD collector CFN template.
