### PR TITLE
Add missing param LogArchiveAccount to ct-al-master-stackset

### DIFF
--- a/template/ct-al-master-stackset.yaml
+++ b/template/ct-al-master-stackset.yaml
@@ -14,6 +14,12 @@ Parameters:
     AllowedPattern: "^[0-9]{12}$"
     MinLength: 12
     MaxLength: 12
+  LogArchiveAccount:
+    Type: String
+    Description: Designated AWS Control Tower Log Archive account
+    AllowedPattern: '^[0-9]{12}$'
+    MinLength: 12
+    MaxLength: 12
   AlertLogicCustomerId:
     Type: String
     Description: AlertLogic Customer Id
@@ -112,6 +118,22 @@ Conditions:
   SecurityAccount: !Equals
     - !Ref SecurityAccount
     - !Ref AWS::AccountId
+
+  SecurityAccountOriginRegion: !And
+    - !Equals
+      - !Ref SecurityAccount
+      - !Ref AWS::AccountId
+    - !Equals
+      - !Ref MasterRegion
+      - !Ref AWS::Region
+
+  LogArchiveOriginRegion: !And
+    - !Equals
+      - !Ref LogArchiveAccount
+      - !Ref AWS::AccountId
+    - !Equals
+      - !Ref MasterRegion
+      - !Ref AWS::Region
 
 Resources:
   ALRoleFromCFT:


### PR DESCRIPTION
inadvertently removed required param by the ct_al_onboarding function for creating the AlertLogic-CT stackset instance part of 78fab9251f1e7f0df7d717a86b1845d1c396ae7d commit

Error caused:

```sh
[ERROR]	2022-02-23T00:23:24.387Z	fef36e35-9d08-441d-a499-645eb3128923	StackSet error(AlertLogic-CT) : An error occurred (ValidationError) when calling the CreateStackSet operation: Parameters: [LogArchiveAccount] do not exist in the template
```

Signed-off-by: Muram Mohamed <mmohamed@alertlogic.com>
